### PR TITLE
Bumping React peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "make test"
   },
   "peerDependencies": {
-    "react": ">= 0.10.0 < 1.x"
+    "react": ">= 0.10.0 < 16.x"
   },
   "devDependencies": {
     "react": "0.12.2",


### PR DESCRIPTION
Updating for compatibility with React's new versioning scheme. You may want to swap this out for something even more open since it seems like the component API is pretty stable at this point, but I wanted to keep consistent with the current scheme.
